### PR TITLE
fix: clamp MIDI sample positions to prevent Renoise crashes

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -761,7 +761,8 @@ void TetraOPAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce:
     for (const auto metadata : midiMessages)
     {
         auto message = metadata.getMessage();
-        int newPos = metadata.samplePosition * osfactor;
+        int safePos = juce::jlimit(0, buffer.getNumSamples() - 1, metadata.samplePosition);
+        int newPos = safePos * osfactor;
         oversampledMidi.addEvent(message, newPos);
     }
 


### PR DESCRIPTION
Renoise occasionally schedules MIDI events at the absolute boundary of the audio block (samplePosition == numSamples). When multiplied by the oversampling factor, this caused out-of-bounds array indexing.

Added juce::jlimit to safely clamp the incoming sample position to (numSamples - 1) before the oversampling multiplier is applied.