### PR TITLE
Fix oversampled block position tracking in PluginProcessor

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -776,7 +776,7 @@ void TetraOPAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce:
         int thisBlock = std::min(todo, MAX_BLOCKSIZE / osfactor);
 
         currBlockSize = thisBlock;
-        currBlockPos = pos;
+        currBlockPos = pos * osfactor;
 
         modulation->tick((double)osrate,
             thisBlock * osfactor,


### PR DESCRIPTION
- Correct `currBlockPos` to use oversampled samples (`pos * osfactor`)
- Aligns voice/filter timing and modulation offsets with the oversampled render path
- Prevents incorrect `blkoffset` calculations in `Voice::startBlock()` / `OSC::startBlock()`